### PR TITLE
Update bibtypst-styles.typ

### DIFF
--- a/src/bibtypst-styles.typ
+++ b/src/bibtypst-styles.typ
@@ -26,11 +26,73 @@
 #let language(reference, options) = {
   printfield(reference, "language", options)
 }
+#let month-number-to-name(month-num, bibstring) = {
+  if month-num == none { return none }
 
+  let month-names = (
+    "01": "january",
+    "02": "february", 
+    "03": "march",
+    "04": "april",
+    "05": "may",
+    "06": "june",
+    "07": "july",
+    "08": "august",
+    "09": "september",
+    "10": "october",
+    "11": "november",
+    "12": "december",
+    // Serving months without zeros
+    "1": "january",
+    "2": "february",
+    "3": "march", 
+    "4": "april",
+    "5": "may",
+    "6": "june",
+    "7": "july",
+    "8": "august",
+    "9": "september"
+  )
+
+  let month-key = month-names.at(str(month-num), default: none)
+  if month-key != none {
+    bibstring.at(month-key, default: month-num)
+  } else {
+    month-num
+  }
+}
 
 #let date(reference, options) = {
+  let date-field = fd(reference, "date", options)
+
+  let formatted-date = if date-field != none {
+    let date-str = str(date-field)
+    if date-str.contains("-") {
+      let parts = date-str.split("-")
+      if parts.len() >= 3 {
+        // Format: day month year
+        let day = parts.at(2)
+        let month-name = month-number-to-name(parts.at(1), options.bibstring)
+        let year = parts.at(0)
+        strfmt("{} {} {}", day, month-name, year)
+      } else if parts.len() == 2 {
+        // Format: month year
+        let month-name = month-number-to-name(parts.at(1), options.bibstring)
+        let year = parts.at(0)
+        strfmt("{} {}", month-name, year)
+      } else {
+        parts.at(0) // only year
+      }
+    } else {
+      date-str
+    }
+  } else {
+    // Fallback to 'year' field
+    fd(reference, "year", options)
+  }
+
   epsilons(
-    fd(reference, "year", options), // TODO this is probably incomplete
+    formatted-date,
     printfield(reference, "extradate", options)
   )
 }


### PR DESCRIPTION
This is a basic implementation of the ```date``` field in Biblatex, allowing to display the full publication date (tested on the authoryear style). The pull preliminarily requires both ```year``` and ```date``` fields in bibliographic entries, so that the in-text citations would be properly displayed.

Example:

```
@article{hershcovichItMeaningThat2021,
  title = {It's the {{Meaning That Counts}}: {{The State}} of the {{Art}} in {{NLP}} and {{Semantics}}},
  author = {Hershcovich, Daniel and Donatelli, Lucia},
  date = {2021-05-05},
  year = {2021},
  edition = {3},
  journal = {KI - K{\"u}nstliche Intelligenz},
  volume = {35},
  number = {3},
  pages = {255--270},
  issn = {1610-1987},
  doi = {10.1007/s13218-021-00726-6},
  award = {Not really an award},
  abstract = {Semantics, the study of meaning, is central to research in Natural Language Processing (NLP) and many other fields connected to Artificial Intelligence. Nevertheless, how semantics is understood in NLP ranges from traditional, formal linguistic definitions based on logic and the principle of compositionality to more applied notions based on grounding meaning in real-world objects and real-time interaction. ``Semantic'' methods may additionally strive for meaningful representation of language that integrates broader aspects of human cognition and embodied experience, calling into question how adequate a representation of meaning based on linguistic signal alone is for current research agendas. We review the state of computational semantics in NLP and investigate how different lines of inquiry reflect distinct understandings of semantics and prioritize different layers of linguistic meaning. In conclusion, we identify several important goals of the field and describe how current research addresses them.},
  langid = {english}
}
```

<img width="906" height="91" alt="obraz" src="https://github.com/user-attachments/assets/1d255623-881b-4424-a79e-5d711d8b429b" />
