### PR TITLE
support suffixes in alphabetic and numeric style

### DIFF
--- a/src/citation-styles.typ
+++ b/src/citation-styles.typ
@@ -85,6 +85,10 @@
     /// -> str | content
     citation-separator: ", ",
 
+    /// The string that separates the suffix from the citation.
+    /// -> str
+    suffix-separator: ", ",
+
     /// Wraps text in square brackets. The argument needs to be a function
     /// that takes one argument (`str` or `content`) and returns `content`.
     /// 
@@ -117,6 +121,8 @@
 
 
   let list-formatter(reference-dicts, form, options) = {
+    let suffix = options.at("suffix", default: none)
+
     let individual-form = "n"
     let individual-citations = reference-dicts.map(x => {
       if type(x) == str {
@@ -129,10 +135,12 @@
     })
 
     let joined = individual-citations.join(citation-separator)
+    let joined-with-suffix = fjoin(suffix-separator, joined, suffix)
+
     if form != "n" {
-      format-brackets(joined)
+      format-brackets(joined-with-suffix)
     } else {
-      joined
+      joined-with-suffix
     }
   }
 
@@ -528,6 +536,10 @@
     /// -> str | content
     compact-separator: [--],
 
+    /// The string that separates the suffix from the citation.
+    /// -> str
+    suffix-separator: ", ",
+
     /// Wraps text in square brackets. The argument needs to be a function
     /// that takes one argument (`str` or `content`) and returns `content`.
     /// 
@@ -539,6 +551,8 @@
     format-brackets: nn(it => [[#it]]),
   ) = {
   let list-formatter(reference-dicts, form, options) = {
+    let suffix = options.at("suffix", default: none)
+
     let individual-citations = reference-dicts.map(x => {
       if type(x) == str {
         [*?#x?*]
@@ -610,10 +624,12 @@
       individual-citations.map(x => if type(x) == array { x.at(1) } else { x }).join(citation-separator)
     }
 
+    let joined-with-suffix = fjoin(suffix-separator, joined, suffix)
+
     if form != "n" {
-      format-brackets(joined)
+      format-brackets(joined-with-suffix)
     } else {
-      joined
+      joined-with-suffix
     }
   }
 


### PR DESCRIPTION
# Description

Currently, only the authoryear style supports the suffix and prefix citation options; the other built-in styles just ignore these options. This PR adds support for suffixes for the alphabetic and numeric styles by essentially copying the logic in `format-citation-authoryear`:

```typ
let suffix = options.at("suffix", default: none)

// ...

let joined-with-suffix = fjoin(suffix-separator, joined, suffix)
```

While prefixes could have been implemented in this way too, I'm not sure if an outlput like [e.g. 1] would make sense (compared to e.g. [1]). Maybe for the alphabetic and numeric styles, the prefix could be placed in front of the bracket?

# Minimal example

```typ
#import "lib.typ": *
#set page(height: auto)

#add-bib-resource(
  "
@book{Hannabuss1997,
  title = {An Introduction to Quantum Theory},
  ISBN = {9781383026283},
  publisher = {Oxford University PressOxford},
  author = {Hannabuss,  Keith},
  year = {1997},
  month = mar
}
",
)

= Suffix

#let style = format-citation-authoryear()
#refsection(format-citation: style.format-citation)[
  == authoryear

  #cite("Hannabuss1997", suffix: "Def. 2.1.1.", prefix: "hello")

  #print-bibliography(
    show-all: true,
    title: none,
    format-reference: format-reference(reference-label: style.reference-label),
    label-generator: style.label-generator,
  )
]

#let style = format-citation-alphabetic()
#refsection(format-citation: style.format-citation)[
  == alphabetic

  #cite("Hannabuss1997", suffix: "Def. 2.1.1.")

  #print-bibliography(
    show-all: true,
    title: none,
    format-reference: format-reference(reference-label: style.reference-label),
    label-generator: style.label-generator,
  )
]

#let style = format-citation-numeric()
#refsection(format-citation: style.format-citation)[
  == numeric

  #cite("Hannabuss1997", suffix: "Def. 2.1.1.")

  #print-bibliography(
    show-all: true,
    title: none,
    format-reference: format-reference(reference-label: style.reference-label),
    label-generator: style.label-generator,
  )
]
```

## Before

<img width="1191" height="723" alt="suffix" src="https://github.com/user-attachments/assets/ecb0620c-8daa-410d-a73e-4d5cd9cc8e73" />

## After

<img width="1191" height="723" alt="suffix" src="https://github.com/user-attachments/assets/87ab4dc8-665a-4a41-bf18-eccf9d906527" />

